### PR TITLE
Add missing language attribute (English)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#65c89b",
+    "activityBar.background": "#65c89b",
+    "activityBar.foreground": "#15202b",
+    "activityBar.inactiveForeground": "#15202b99",
+    "activityBarBadge.background": "#945bc4",
+    "activityBarBadge.foreground": "#e7e7e7",
+    "commandCenter.border": "#15202b99",
+    "sash.hoverBorder": "#65c89b",
+    "statusBar.background": "#42b883",
+    "statusBar.foreground": "#15202b",
+    "statusBarItem.hoverBackground": "#359268",
+    "statusBarItem.remoteBackground": "#42b883",
+    "statusBarItem.remoteForeground": "#15202b",
+    "titleBar.activeBackground": "#42b883",
+    "titleBar.activeForeground": "#15202b",
+    "titleBar.inactiveBackground": "#42b88399",
+    "titleBar.inactiveForeground": "#15202b99"
+  },
+  "peacock.color": "#42b883"
+}

--- a/mistakes.html
+++ b/mistakes.html
@@ -19,7 +19,7 @@
     >
       <div class="flex flex-col gap-4 md:ml-6">
         <p class="text-6xl md:text-left text-center">What's for dessert?</p>
-        <p class="italic black">
+        <p class="italic text-slate-400">
           This page has several mistakes which could impact both its
           accessibility and usability! Check out the README in the
           <a

--- a/mistakes.html
+++ b/mistakes.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -130,7 +130,7 @@
           these popular grocery outlets:
         </p>
 
-         <ul class="list-disc list-inside">
+        <ul class="list-disc list-inside">
           <li>
             <a
               class="underline text-fuchsia-800 hover:no-underline"

--- a/mistakes.html
+++ b/mistakes.html
@@ -19,7 +19,7 @@
     >
       <div class="flex flex-col gap-4 md:ml-6">
         <p class="text-6xl md:text-left text-center">What's for dessert?</p>
-        <p class="italic text-slate-400">
+        <p class="italic black">
           This page has several mistakes which could impact both its
           accessibility and usability! Check out the README in the
           <a


### PR DESCRIPTION
**Error:** There was a missing language attribute in the html tag.
The error was immediately highlighted by the axe Linter tool.

**Relevant WCAG:** [SC 3.1.1](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page)