### PR TITLE
Update header text to black for higher contrast

### DIFF
--- a/mistakes.html
+++ b/mistakes.html
@@ -19,7 +19,7 @@
     >
       <div class="flex flex-col gap-4 md:ml-6">
         <p class="text-6xl md:text-left text-center">What's for dessert?</p>
-        <p class="italic text-slate-400">
+        <p class="italic black">
           This page has several mistakes which could impact both its
           accessibility and usability! Check out the README in the
           <a
@@ -130,7 +130,7 @@
           these popular grocery outlets:
         </p>
 
-         <ul class="list-disc list-inside">
+        <ul class="list-disc list-inside">
           <li>
             <a
               class="underline text-fuchsia-800 hover:no-underline"


### PR DESCRIPTION
**Error**: The font color for the text in the header was not of a high enough contrast (checked on [](https://webaim.org/resources/contrastchecker/)). The color was updated to black to guarantee good contrast.

**Relevant WCAG**: [SC1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum)